### PR TITLE
exposing debug option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ To configure this add-on, you must set the following parameters via the Hass.io 
 |`serial_port`|string|yes|Serial port for your CC2531 stick.|
 |`mqtt_user`|string|no|Your MQTT username, if set.|
 |`mqtt_pass`|string|no|Your MQTT Password, if set.|
+|`debug`|bool|no|Set to true to enable debug mode for zigbee-shepherd and zigbee2mqtt. See [the wiki](https://github.com/Koenkk/zigbee2mqtt/wiki/How-to-debug) for more information.|
 
 Note: Depending on your configuration, the MQTT server URL is likely to include the internal Docker host IP address (`172.17.0.1`) and the port specified elsewhere, typically `1883` or `8883` for SSL communications. For example, `mqtt://172.17.0.1:1883`.
 

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -24,7 +24,8 @@
     "mqtt_server": "str",
     "serial_port": "str",
     "mqtt_user": "str?",
-    "mqtt_pass": "str?"
+    "mqtt_pass": "str?",
+    "debug": "bool?"
   },
   "image": "dwelch2101/zigbee2mqtt-{arch}"
 }

--- a/zigbee2mqtt/run.sh
+++ b/zigbee2mqtt/run.sh
@@ -3,7 +3,12 @@
 CONFIG_PATH=/data/options.json
 
 DATA_PATH=$(jq --raw-output ".data_path" $CONFIG_PATH)
+DEBUG_ZIGBEE2MQTT=$(jq --raw-output "debug" $CONFIG_PATH)
 
 python3 "$CONFIG_PATH" "$DATA_PATH"
 
-ZIGBEE2MQTT_DATA="$DATA_PATH" npm start
+if $DEBUG_ZIGBEE2MQTT; then
+    DEBUG=* ZIGBEE2MQTT_DATA="$DATA_PATH" npm start
+else
+    ZIGBEE2MQTT_DATA="$DATA_PATH" npm start
+fi


### PR DESCRIPTION
Addressing #10 

Adds a `debug` option to `config.json`, which enables DEBUG mode for zigbee2mqtt and zigbee-shepherd