### PR TITLE
Fix device mapping

### DIFF
--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -3,7 +3,7 @@
   "version": "test",
   "slug": "zigbee2mqtt",
   "description": "Zigbee to MQTT Bridge",
-  "devices": ["/dev/ttyACM0:/dev/ttyACM0:rwm"],
+  "auto_uart": true,
   "url": "https://github.com/danielwelch/hassio-zigbee2mqtt",
   "startup": "before",
   "boot": "auto",


### PR DESCRIPTION
The [Hass.io dev docs](https://developers.home-assistant.io/docs/en/hassio_addon_config.html) make it seem like the `auto_uart` option will fix our issue with device mapping. It just maps all serial devices from host into add-on.

@ciotlosm this may be the solution to the device mapping issue 