### PR TITLE
Added pm2 and permit_join through interface docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,45 @@ Note: Depending on your configuration, the MQTT server URL will need to include 
 
 Note: To find out which serial ports you have exposed go to **Hass.io > System > Host system > Show Hardware**
 
+### Pairing
+
+To allow pairing in a better way, it's recommended you leave `permit_join` to false, and use the following code to get a pairing button inside **Home Assistant**:
+
+```
+input_boolean:
+  zigbee_permit_join:
+    name: Allow Zigbee joining
+    initial: off
+    icon: mdi:cellphone-wireless
+
+mqtt:
+  broker: homeassistant # This will have to be your mqtt broker
+  discovery: true
+
+
+automation:
+  - alias: Enable Zigbee joining
+    trigger:
+       platform: state
+       entity_id: input_boolean.zigbee_permit_join
+       to: 'on'
+    action:
+      - service: mqtt.publish
+        data:
+          topic: zigbee2mqtt/bridge/config/permit_join
+          payload: "true"
+  - alias: Disable Zigbee joining
+    trigger:
+       platform: state
+       entity_id: input_boolean.zigbee_permit_join
+       to: 'off'
+    action:
+      - service: mqtt.publish
+        data:
+          topic: zigbee2mqtt/bridge/config/permit_join
+          payload: "false"
+```
+
 ### Issues
 
 This addon is currently still work in progress. If you find any issues with it, please check first the [issue tracker](https://github.com/danielwelch/hassio-zigbee2mqtt/issues). 

--- a/zigbee2mqtt/Dockerfile
+++ b/zigbee2mqtt/Dockerfile
@@ -15,6 +15,7 @@ COPY set_config.py /app/set_config.py
 WORKDIR /app
 
 RUN ["chmod", "a+x", "/app/run.sh"]
+RUN ["npm", "install", "--unsafe-perm", "-g", "pm2"]
 RUN ["npm", "install", "--unsafe-perm"]
 RUN apk del make gcc g++ python2 linux-headers udev git
 

--- a/zigbee2mqtt/run.sh
+++ b/zigbee2mqtt/run.sh
@@ -15,5 +15,5 @@ fi
 if [[ ! -z "$ERR_LOG" ]]; then
     ZIGBEE2MQTT_DATA="$DATA_PATH" npm start 1> "$DATA_PATH"/out.log 2> "$DATA_PATH"/err.log
 else
-    ZIGBEE2MQTT_DATA="$DATA_PATH" npm start
+    ZIGBEE2MQTT_DATA="$DATA_PATH" pm2-runtime start npm -- start
 fi


### PR DESCRIPTION
- Added pm2 https://github.com/danielwelch/hassio-zigbee2mqtt/issues/2
- Added documentation for allow on the fly `permit_join` from home assistant https://github.com/danielwelch/hassio-zigbee2mqtt/issues/15

<img width="504" alt="screen shot 2018-05-28 at 21 57 04" src="https://user-images.githubusercontent.com/7738048/40626663-ae4235d4-62c2-11e8-8361-dce623defb1e.png">

Note: Might be worth changing version to 0.1 after this is tested.

