### PR TITLE
updating options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,25 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+This project is versioned based upon the version of [zigbee2mqtt](https://github.com/Koenkk/zigbee2mqtt). The versioning `X.Y.Z` of the stable release of this add-on will track that of zigbee2mqtt. If there are new releases without upgrades to the zigbee2mqtt version (i.e., changes to the add-on that occur between releases of zigbee2mqtt), an additional number will be added to indicate this (`X.Y.Z.A`, where `A` indicates a new versioned release).
+
+## [0.1.3.1](https://github.com/danielwelch/hassio-zigbee2mqtt/releases/tag/v0.1.2) - 2018-09-17
+### Changed
+- Includes new or changed options for zigbee2mqtt:
+    - `mqtt_client_id`
+    - `disable_led` (*renamed from `serial_disable_led`*)
+    - `cache_state`
+    - `log_directory`
+    - `log_level`
+    - `rtscts`
+    - `zigbee_shepherd_debug`
+
+
+## [0.1.3](https://github.com/danielwelch/hassio-zigbee2mqtt/releases/tag/v0.1.2) - 2018-07-31
+### Changed
+- Upgrade to version 0.1.3 of `zigbee2mqtt`
 
 ## [0.1.2](https://github.com/danielwelch/hassio-zigbee2mqtt/releases/tag/v0.1.2) - 2018-07-31
 ### Changed

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To configure this add-on, you must set the following parameters via the Hass.io 
 |`mqtt_user`|string|no|Your MQTT username, if set.|
 |`mqtt_pass`|string|no|Your MQTT Password, if set.|
 |`log_level`|"debug"\|"info"\|"warn"\|"error"|no|Set to true to enable debug mode for zigbee-shepherd and zigbee2mqtt. See [the wiki](https://github.com/Koenkk/zigbee2mqtt/wiki/How-to-debug) for more information.|
-|`log_directory`|string|no|Your MQTT Password, if set.|
+|`log_directory`|string|no|If set, zigbee2mqtt will store logs in this directory. The directory will be a sub-directory of the `data_path` in `/share` (set above). This option must be set to a directory (for example: `"log_directory": "logs/"` will store logs in `/share/zigbee2mqtt/logs/` by default).|
 |`disable_led`|string|no|Your MQTT Password, if set.|
 |`rtscts`|bool|no|RTS / CTS Hardware Flow Control for serial port|
 |`cache_state`|bool|no|Optional state caching. See [here](https://github.com/Koenkk/zigbee2mqtt/commit/9396bde1f3b022e0f634487d1a37d2a5127c8cb3#diff-f68567477d803b49930337bf7fe1556bR16).|

--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ To configure this add-on, you must set the following parameters via the Hass.io 
 |`serial_disable_led`|bool|no|Disable the LED of your CC2531 stick.|
 |`mqtt_user`|string|no|Your MQTT username, if set.|
 |`mqtt_pass`|string|no|Your MQTT Password, if set.|
-|`debug`|bool|no|Set to true to enable debug mode for zigbee-shepherd and zigbee2mqtt. See [the wiki](https://github.com/Koenkk/zigbee2mqtt/wiki/How-to-debug) for more information.|
-|`err`|bool|no|Set to true to redirect zigbee2mqtt `stdout` to `out.log` and `stderr` to `err.log`. Both `out.log` and `err.log` will be located within `data_path` above.|
+|`log_level`|"debug"\|"info"\|"warn"\|"error"|no|Set to true to enable debug mode for zigbee-shepherd and zigbee2mqtt. See [the wiki](https://github.com/Koenkk/zigbee2mqtt/wiki/How-to-debug) for more information.|
+|`log_directory`|string|no|Your MQTT Password, if set.|
+|`disable_led`|string|no|Your MQTT Password, if set.|
+|`rtscts`|bool|no|RTS / CTS Hardware Flow Control for serial port|
+|`cache_state`|bool|no|Optional state caching. See [here](https://github.com/Koenkk/zigbee2mqtt/commit/9396bde1f3b022e0f634487d1a37d2a5127c8cb3#diff-f68567477d803b49930337bf7fe1556bR16).|
 
 Notes:
 - Depending on your configuration, the MQTT server URL will need to include the port, typically `1883` or `8883` for SSL communications. For example, `mqtt://homeassistant:1883`.

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -23,11 +23,14 @@
     "mqtt_base_topic": "str",
     "mqtt_server": "str",
     "serial_port": "str",
-    "serial_disable_led": "bool?",
     "mqtt_user": "str?",
     "mqtt_pass": "str?",
-    "debug": "bool?",
-    "err": "bool?"
+    "mqtt_client_id": "str?",
+    "disable_led": "bool?",
+    "cache_state": "bool?",
+    "log_directory": "str?",
+    "log_level": "match(^info|debug|warn|error$)?",
+    "rtscts": "bool?"
   },
   "image": "dwelch2101/zigbee2mqtt-edge-{arch}"
 }

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -23,11 +23,14 @@
     "mqtt_base_topic": "str",
     "mqtt_server": "str",
     "serial_port": "str",
-    "serial_disable_led": "bool?",
     "mqtt_user": "str?",
     "mqtt_pass": "str?",
-    "debug": "bool?",
-    "err": "bool?"
+    "mqtt_client_id": "str?",
+    "disable_led": "bool?",
+    "cache_state": "bool?",
+    "log_directory": "str?",
+    "log_level": "match(^info|debug|warn|error$)?",
+    "rtscts": "bool?"
   },
   "image": "dwelch2101/zigbee2mqtt-{arch}"
 }

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "zigbee2mqtt",
-  "version": "0.1.3",
+  "version": "0.1.3.1",
   "slug": "zigbee2mqtt",
   "description": "Zigbee to MQTT Bridge",
   "auto_uart": true,
@@ -30,6 +30,7 @@
     "cache_state": "bool?",
     "log_directory": "str?",
     "log_level": "match(^info|debug|warn|error$)?",
+    "zigbee_shepherd_debug": "bool?",
     "rtscts": "bool?"
   },
   "image": "dwelch2101/zigbee2mqtt-{arch}"

--- a/zigbee2mqtt/run.sh
+++ b/zigbee2mqtt/run.sh
@@ -4,6 +4,12 @@ CONFIG_PATH=/data/options.json
 
 DATA_PATH=$(jq --raw-output ".data_path" $CONFIG_PATH)
 
+ZIGBEE_SHEPHERD_DEBUG=$(jq --raw-output ".zigbee_shepherd_debug // empty" $CONFIG_PATH)
+
 python3 set_config.py "$CONFIG_PATH" "$DATA_PATH"
+
+if [[ ! -z "$ZIGBEE_SHEPHERD_DEBUG" ]]; then
+    export DEBUG="zigbee-shepherd*" 
+fi
 
 ZIGBEE2MQTT_DATA="$DATA_PATH" pm2-runtime start npm -- start

--- a/zigbee2mqtt/run.sh
+++ b/zigbee2mqtt/run.sh
@@ -3,18 +3,7 @@
 CONFIG_PATH=/data/options.json
 
 DATA_PATH=$(jq --raw-output ".data_path" $CONFIG_PATH)
-DEBUG_ZIGBEE2MQTT=$(jq --raw-output ".debug // empty" $CONFIG_PATH)
-ERR_LOG=$(jq --raw-output ".err // empty" $CONFIG_PATH)
 
 python3 set_config.py "$CONFIG_PATH" "$DATA_PATH"
 
-if [[ ! -z "$DEBUG_ZIGBEE2MQTT" ]]; then
-    export DEBUG=*
-fi
-
-
-if [[ ! -z "$ERR_LOG" ]]; then
-    ZIGBEE2MQTT_DATA="$DATA_PATH" npm start 1> "$DATA_PATH"/out.log 2> "$DATA_PATH"/err.log
-else
-    ZIGBEE2MQTT_DATA="$DATA_PATH" pm2-runtime start npm -- start
-fi
+ZIGBEE2MQTT_DATA="$DATA_PATH" pm2-runtime start npm -- start

--- a/zigbee2mqtt/set_config.py
+++ b/zigbee2mqtt/set_config.py
@@ -4,6 +4,40 @@ from pathlib import Path
 import yaml
 
 
+class ConfigBuilder:
+    def __init__(self, config, options):
+        self.config = config
+        self.options = options
+
+    def set_option(self, option_name, category=None, alt_config_name=None):
+        # some options are optional, skip them if it's not set
+        if self.options.get(option_name, None):
+            if category:
+                if self.config.get(category, None) is None:
+                    self.config[category] = dict()
+                if alt_config_name is None:
+                    self.config[category][option_name] = self.options[
+                        option_name]
+                else:
+                    self.config[category][alt_config_name] = self.options[
+                        option_name]
+            else:
+                if alt_config_name is None:
+                    self.config[option_name] = self.options[option_name]
+                else:
+                    self.config[alt_config_name] = self.options[option_name]
+
+    def get_option(self, option_name, category=None):
+        if category:
+            return self.options.get(category).get(option_name, None)
+        else:
+            return self.options.get(option_name, None)
+
+    def dump(self, config_path):
+        with open(config_path, 'w') as f:
+            yaml.safe_dump(self.config, f, default_flow_style=False)
+
+
 def main(options_path, data_path):
 
     config = dict()
@@ -20,26 +54,31 @@ def main(options_path, data_path):
     with open(options_path) as f:
         options = json.load(f)
 
-    config['homeassistant'] = options["homeassistant"]
-    config['permit_join'] = options["permit_join"]
-    if config.get('mqtt', None) is None:
-        config['mqtt'] = dict()
-    config['mqtt']['base_topic'] = options["mqtt_base_topic"]
-    config['mqtt']['server'] = options["mqtt_server"]
+    config = ConfigBuilder(config, options)
+
+    config.set_option('homeassistant')
+    config.set_option('permit_join')
+
+    config.set_option(
+        'mqtt_base_topic', category='mqtt', alt_config_name='base_topic')
+    config.set_option('mqtt_server', category='mqtt', alt_config_name='server')
+    config.set_option(
+        'mqtt_client_id', category='mqtt', alt_config_name='client_id')
 
     if options.get("mqtt_user", None) or options.get("mqtt_pass", None):
-        config['mqtt']['user'] = options["mqtt_user"]
-        config['mqtt']['password'] = options["mqtt_pass"]
+        config.set_option('mqtt_user', category='mqtt', alt_config_name='user')
+        config.set_option(
+            'mqtt_pass', category='mqtt', alt_config_name='password')
 
-    if config.get('serial', None) is None:
-        config['serial'] = dict()
-    config['serial']['port'] = options["serial_port"]
-    if options.get("serial_disable_led", None):
-        config['serial']['disable_led'] = options["serial_disable_led"]
+    config.set_option('serial_port', category='serial', alt_config_name='port')
+    config.set_option('disable_led', category='serial')
 
-    with open(config_path, 'w') as f:
-        yaml.safe_dump(config, f, default_flow_style=False)
+    config.set_option('cache_state', category='advanced')
+    # config.set_option('log_directory')
+    config.set_option('log_level', category='advanced')
+    config.set_option('rtscts', category='advanced')
 
+    config.dump(config_path)
     print('[Info] Configuration written to {}'.format(config_path))
 
 

--- a/zigbee2mqtt/set_config.py
+++ b/zigbee2mqtt/set_config.py
@@ -37,6 +37,10 @@ class ConfigBuilder:
         with open(config_path, 'w') as f:
             yaml.safe_dump(self.config, f, default_flow_style=False)
 
+    def set_log_dir(self, data_path):
+        log_dir = Path(data_path).joinpath(self.options["log_directory"])
+        self.config["advanced"]["log_directory"] = log_dir
+
 
 def main(options_path, data_path):
 
@@ -74,7 +78,8 @@ def main(options_path, data_path):
     config.set_option('disable_led', category='serial')
 
     config.set_option('cache_state', category='advanced')
-    # config.set_option('log_directory')
+    config.set_log_dir(data_path, options['log_directory'])
+    config.set_option('log_directory', category='advanced')
     config.set_option('log_level', category='advanced')
     config.set_option('rtscts', category='advanced')
 


### PR DESCRIPTION
Addresses #50 

- remove `debug` and `err` options from hass.io UI, as I think the logging in zigbee2mqtt has improved and this should no longer be necessary.
- refactor how zigbee2mqtt config is built so it's easier to add more options later if needed

Todo:
- [x] set log directory in zigbee2mqtt config
- [x] bump version (minor)