### PR TITLE
Make use of nested configuration **Breaking Change**

### DIFF
--- a/zigbee2mqtt-edge/Dockerfile
+++ b/zigbee2mqtt-edge/Dockerfile
@@ -4,24 +4,17 @@ FROM $BUILD_FROM
 # Add env
 ENV LANG C.UTF-8
 
-COPY requirements.txt /requirements.txt
-
 RUN apk add --update --no-cache \
-    jq nodejs>10.14.2 npm python3 python3-dev \
-    python2 make gcc g++ linux-headers udev git && \
+    jq nodejs nodejs-npm \
+    make gcc g++ linux-headers udev git python2 && \
   git clone -b dev --single-branch --depth 1 https://github.com/Koenkk/zigbee2mqtt.git /app && \
-  cp /requirements.txt /app/requirements.txt && \
-  pip3 install --no-cache-dir -r /app/requirements.txt && \
   cd /app && \
-  echo "Installed zigbee2mqtt @ version $(eval git rev-parse --short HEAD)" && \
-  rm ./npm-shrinkwrap.json && \
   npm install --unsafe-perm -g pm2 && \
   npm install --unsafe-perm && \
-  apk del make gcc g++ python2 linux-headers udev git
+  apk del make gcc g++ linux-headers udev git python2 && \
+  rm -rf /app/docs /app/test /app/images /app/scripts /app/data /app/docker /app/LICENSE /app/README.md /app/update.sh
 
-COPY run.sh /app/run.sh
-COPY set_config.py /app/set_config.py
-
-RUN ["chmod", "a+x", "/app/run.sh"]
+COPY run.sh /run.sh
+RUN ["chmod", "a+x", "run.sh"]
 WORKDIR /app
-CMD [ "/app/run.sh" ]
+CMD [ "/run.sh" ]

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -1,63 +1,88 @@
 {
-  "name": "zigbee2mqtt-edge",
-  "version": "test",
-  "slug": "zigbee2mqtt-edge",
-  "description": "Development build of the zigbee2mqtt add-on.",
-  "auto_uart": true,
-  "url": "https://github.com/danielwelch/hassio-zigbee2mqtt",
-  "startup": "before",
-  "boot": "auto",
-  "map": ["share:rw"],
-  "options": {
-    "data_path": "/share/zigbee2mqtt",
-    "homeassistant": true,
-    "permit_join": false,
-    "mqtt_base_topic": "zigbee2mqtt",
-    "mqtt_server": "mqtt://homeassistant",
-    "serial_port": "/dev/ttyACM0",
-    "devices": [],
-    "network_key": []
-  },
-  "schema": {
-    "data_path": "str",
-    "homeassistant": "bool",
-    "permit_join": "bool",
-    "mqtt_base_topic": "str",
-    "mqtt_server": "str",
-    "serial_port": "str",
-    "mqtt_user": "str?",
-    "mqtt_pass": "str?",
-    "mqtt_client_id": "str?",
-    "reject_unauthorized": "bool?",
-    "disable_led": "bool?",
-    "cache_state": "bool?",
-    "log_directory": "str?",
-    "log_level": "match(^info|debug|warn|error$)?",
-    "rtscts": "bool?",
-    "include_device_information": "bool?",
-    "soft_reset_timeout": "int?",
-    "pan_id": "str?",
-    "channel": "int?",
-    "zigbee_shepherd_devices": "bool?",
-    "zigbee_shepherd_debug": "bool?",
-    "availability_timeout": "int?",
-    "last_seen": "str?",
-    "elapsed": "bool?",
-    "overwrite": "bool?",
-    "devices": [
-      {
-        "id": "str",
-        "friendly_name": "str?",
-        "retain": "bool?",
-        "report": "bool?",
-        "qos": "int?",
-        "occupancy_timeout": "int?",
-        "temperature_precision": "int?",
-        "humidity_precision": "int?",
-        "pressure_precision": "int?"
-      }
-    ],
-    "network_key": ["int?"]
-  },
-  "image": "dwelch2101/zigbee2mqtt-edge-{arch}"
+    "name": "zigbee2mqtt-edge",
+    "version": "test",
+    "slug": "zigbee2mqtt-edge",
+    "description": "Development build of the zigbee2mqtt add-on.",
+    "auto_uart": true,
+    "url": "https://github.com/danielwelch/hassio-zigbee2mqtt",
+    "startup": "before",
+    "boot": "auto",
+    "map": ["share:rw"],
+    "options": {
+        "data_path": "/share/zigbee2mqtt",
+        "devices": [],
+
+        "homeassistant": true,
+        "permit_join": false,
+        "mqtt": {
+            "base_topic": "zigbee2mqtt",
+            "server": "mqtt://homeassistant",
+            "user": "my_user",
+            "password": "my_password",
+            "client_id": "MY_CLIENT_ID",
+            "reject_unauthorized": true,
+            "include_device_information": true
+        },
+        "serial":{
+            "port": "/dev/ttyACM0",
+            "disable_led": false
+        },
+        "advanced": {
+            "pan_id": 6754,
+            "channel": 11,
+            "cache_state": true,
+            "log_level": "info",
+            "log_directory": "/data/log/%TIMESTAMP%",
+            "baudrate": 115200,
+            "rtscts": true,
+            "soft_reset_timeout": 0,
+            "network_key": [1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13],
+            "last_seen": "disable",
+            "elapsed": false,
+            "availability_timeout": 0
+        }
+    },
+    "schema": {
+        "data_path": "str",
+        "devices": [{
+            "id": "str",
+            "friendly_name": "str?",
+            "retain": "bool?",
+            "report": "bool?",
+            "qos": "int?",
+            "occupancy_timeout": "int?",
+            "temperature_precision": "int?",
+            "humidity_precision": "int?",
+            "pressure_precision": "int?"
+        }],
+        "homeassistant": "bool",
+        "permit_join": "bool",
+        "mqtt": {
+            "base_topic": "str",
+            "server": "str",
+            "user": "str?",
+            "password": "str?",
+            "client_id": "str?",
+            "reject_unauthorized": "bool?",
+            "include_device_information": "bool?"
+        },
+        "serial":{
+            "port": "str",
+            "disable_led": "bool?"
+        },
+        "advanced": {
+            "pan_id": "int(0,65536)?",
+            "channel": "int(11,26)?",
+            "cache_state": "bool?",
+            "log_level": "match(^info|debug|warn|error$)?",
+            "log_directory": "str?",
+            "baudrate": "match(^110|300|600|1200|2400|4800|9600|14400|19200|28800|38400|56000|57600|115200|128000|153600|230400|256000|460800|921600$)?",
+            "rtscts": "bool?",
+            "soft_reset_timeout": "int?",
+            "network_key": ["int?"],
+            "last_seen": "match(^disable|ISO_8601|epoch)?",
+            "elapsed": "bool?",
+            "availability_timeout": "int?"
+        }
+    }
 }

--- a/zigbee2mqtt-edge/run.sh
+++ b/zigbee2mqtt-edge/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+CONFIG_PATH=/data/options.json
+
+DATA_PATH=$(jq --raw-output ".data_path" $CONFIG_PATH)
+
+# Parse config file
+cp $CONFIG_PATH $DATA_PATH/configuration.yaml
+
+ZIGBEE_SHEPHERD_DEBUG=$(jq --raw-output ".zigbee_shepherd_debug // empty" $CONFIG_PATH)
+ZIGBEE_SHEPHERD_DEVICES=$(jq --raw-output ".zigbee_shepherd_devices // empty" $CONFIG_PATH)
+
+if [[ ! -z "$ZIGBEE_SHEPHERD_DEBUG" ]]; then
+    export DEBUG="zigbee-shepherd*"
+fi
+
+if [[ ! -z "$ZIGBEE_SHEPHERD_DEVICES" ]]; then
+    echo "[Info] Searching for custom devices file in zigbee2mqtt data path..."
+    if [[ -f "$DATA_PATH"/devices.js ]]; then
+        cp -f "$DATA_PATH"/devices.js ./node_modules/zigbee-shepherd-converters/devices.js
+    else
+        echo "[Error] File $DATA_PATH/devices.js not found! Starting with default devices.js"
+    fi
+fi
+
+ZIGBEE2MQTT_DATA="$DATA_PATH" pm2-runtime start npm -- start


### PR DESCRIPTION
Summary:
- Config follows the same structure as the `configuration.yaml` file of z2m
- Removed set_config.py
- Removed all python3 dependencies from docker container
- Image size down to about 180MB
- Made edge build locally
- Needed to ad run.py for zigbe2mqtt-edge because stable and edge are very
  different currently

Note:
- I'm not sure about any kind of upgrade path. Hassio would update the
  default values for options only upon manually deleting the data docker volume
  that was created up on initial addon installation. Thus upon updating, a
  custom `configuration.yaml` file will be overwritten by an invalid one.
  I know from the [AppDaemon](https://www.home-assistant.io/docs/ecosystem/appdaemon/)
  guys, when they had this problem, they updated to a complete new addon name,
  appending a number. E.g. they would make something like:
  `zigbe2mqtt2-edge`
  so custom configurations of `configuration.yaml` like `network_key` wont get
  overwritten.

- The config now provides the same default values as they are documented at
  https://www.zigbee2mqtt.io/configuration/configuration.html I don't know if
  this is a good idea because it might trigger people to belife they have to
  change for e.g. `client_id`.

- I dind't test everything, I mostly made sure it runs at all. In particular
  the `device` config, `pand_id` and `network_key` I'm not sure about.
  `pand_id` and `network_key` expect hey values afak from z2m documentation but
  I couldn't find out if this works with ints as well.