### PR TITLE
Fixes supported architectures

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -6,6 +6,12 @@
   "auto_uart": true,
   "url": "https://github.com/danielwelch/hassio-zigbee2mqtt",
   "startup": "before",
+  "arch": [
+    "aarch64",
+    "amd64",
+    "armhf",
+    "i386"
+  ],
   "boot": "auto",
   "map": ["share:rw"],
   "options": {

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -6,6 +6,12 @@
   "auto_uart": true,
   "url": "https://github.com/danielwelch/hassio-zigbee2mqtt",
   "startup": "before",
+  "arch": [
+    "aarch64",
+    "amd64",
+    "armhf",
+    "i386"
+  ],
   "boot": "auto",
   "map": ["share:rw"],
   "options": {


### PR DESCRIPTION
Hass.io has recently introduced the armv7 architecture.

The add-ons in this repository do not specify the supported architectures, hence it falls back into its default: All architecture. However, armv7 is not available for this add-on, hence people that have a supported armv7 device (e.g., Raspberry Pi 3) will get a 404 not found error on installing this add-on.

This PR fixes it, by explicitly defining the supported architectured in the add-on config. Please note, that an armv7 device, will fallback to armhf automatically. So using this, your add-on will be available on all platforms as usual.

A release of the add-on is not needed for this change.

fixes #123 

@danielwelch You might need to apply the same for the other add-ons. Of course, you can decide to supply armv7 (nice speed boost). But at least this fixes the current issue for now.