### PR TITLE
Create .hash.json during build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
       script:
         - $TRAVIS_BUILD_DIR/build.sh
     - stage: Deploy Docker Images to Docker Hub
-      if: type != pull_request
+      if: type != pull_request AND branch = master
       script:
         - $TRAVIS_BUILD_DIR/distribute.sh
 

--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,8 @@ if [ -z "${TRAVIS_TAG}" ]; then
         --doc-url "${GITHUB_URL}" \
         --login "${DOCKER_USERNAME}" \
         --password "${DOCKER_PASSWORD}" \
-        --parallel
+        --parallel \
+        --arg COMMIT "${TRAVIS_COMMIT}"
 else
     echo "New git tagged build found. Testing building zigbee2mqtt with tag 'latest'."
     docker run -it --rm --privileged --name "${ADDON_NAME}" \
@@ -49,6 +50,7 @@ else
         --doc-url "${GITHUB_URL}" \
         --login "${DOCKER_USERNAME}" \
         --password "${DOCKER_PASSWORD}" \
-        --parallel
+        --parallel \
+        --arg COMMIT "${TRAVIS_COMMIT}"
 fi
 echo "Local Docker build successful."

--- a/distribute.sh
+++ b/distribute.sh
@@ -60,5 +60,6 @@ else
         --doc-url "${GITHUB_URL}" \
         --login "${DOCKER_USERNAME}" \
         --password "${DOCKER_PASSWORD}" \
-        --parallel
+        --parallel \
+        --arg COMMIT "${TRAVIS_COMMIT}"
 fi

--- a/zigbee2mqtt-edge/Dockerfile
+++ b/zigbee2mqtt-edge/Dockerfile
@@ -1,6 +1,9 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
+ARG COMMIT
+ENV COMMIT=$COMMIT
+
 # Add env
 ENV LANG C.UTF-8
 
@@ -17,8 +20,7 @@ RUN apk add --update --no-cache \
 COPY run.sh /app/run.sh
 WORKDIR /app
 
-ARG COMMIT
-RUN jq -n '{"hash": $COMMIT}' > ./.hash.json
+RUN jq -n '{"hash": env.COMMIT}' > ./.hash.json
 
 RUN ["chmod", "a+x", "./run.sh"]
 CMD [ "./run.sh" ]

--- a/zigbee2mqtt-edge/Dockerfile
+++ b/zigbee2mqtt-edge/Dockerfile
@@ -1,8 +1,6 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
-ARG COMMIT
-
 # Add env
 ENV LANG C.UTF-8
 
@@ -19,7 +17,8 @@ RUN apk add --update --no-cache \
 COPY run.sh /app/run.sh
 WORKDIR /app
 
-RUN jq -n '{"hash": env.COMMIT}' > ./.hash.json
+ARG COMMIT
+RUN jq -n '{"hash": $COMMIT}' > ./.hash.json
 
 RUN ["chmod", "a+x", "./run.sh"]
 CMD [ "./run.sh" ]

--- a/zigbee2mqtt-edge/Dockerfile
+++ b/zigbee2mqtt-edge/Dockerfile
@@ -1,6 +1,8 @@
 ARG BUILD_FROM
 FROM $BUILD_FROM
 
+ARG COMMIT
+
 # Add env
 ENV LANG C.UTF-8
 
@@ -16,6 +18,8 @@ RUN apk add --update --no-cache \
 
 COPY run.sh /app/run.sh
 WORKDIR /app
+
+RUN jq -n '{"hash": env.COMMIT}' > ./.hash.json
 
 RUN ["chmod", "a+x", "./run.sh"]
 CMD [ "./run.sh" ]


### PR DESCRIPTION
Pass in travis_commit var to docker build, to create .hash.json during build process. This should be displayed in the log by zigbee2mqtt when ran (see https://github.com/danielwelch/hassio-zigbee2mqtt/issues/146)