### PR TITLE
Change "bool?" to false in default config fixes #197

### DIFF
--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -30,8 +30,7 @@
       "password": "my_password"
     },
     "serial": {
-      "port": "/dev/ttyACM0",
-      "disable_led": false
+      "port": "/dev/ttyACM0"
     },
     "advanced": {
       "pan_id": 6754,

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -31,7 +31,7 @@
     },
     "serial": {
       "port": "/dev/ttyACM0",
-      "disable_led": "bool?"
+      "disable_led": false
     },
     "advanced": {
       "pan_id": 6754,


### PR DESCRIPTION
There is a copy error in the default config. This changes the default config to use false instead of "bool?" from disable_led.