### PR TITLE
Fix error "configuration.yaml: No such file"

### DIFF
--- a/zigbee2mqtt/run.sh
+++ b/zigbee2mqtt/run.sh
@@ -7,6 +7,7 @@ ZIGBEE_SHEPHERD_DEBUG=$(jq --raw-output ".zigbee_shepherd_debug // empty" $CONFI
 ZIGBEE_SHEPHERD_DEVICES=$(jq --raw-output ".zigbee_shepherd_devices // empty" $CONFIG_PATH)
 
 # Check if config exists already
+mkdir -p $DATA_PATH
 if [[ -f $DATA_PATH/configuration.yaml ]]; then
     if [[ ! -f $DATA_PATH/.configuration.yaml.bk ]]; then
         echo "[Info] Configuration file found in data path, but no backup file found in data path. Backing up existing configuration to ${DATA_PATH}/.configuration.yaml.bk"


### PR DESCRIPTION
After installation of addon version 1.5.1.1 I got the following error message:

```
./run.sh: line 20: /share/zigbee2mqtt/configuration.yaml: No such file or directory
```

Creating the directory (DATA_PATH) will fix this issue.