### PR TITLE
Add socat Serial over TCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,23 @@ The stable, versioned zigbee2mqtt can be updated using the standard Hass.io upda
 To update the edge version of the add-on, you will need to uninstall and re-install the add-on. If you have reinstalled the add-on and believe that the latest version has not been installed, try removing the repository before reinstalling.
 
 ----
+### Socat
+
+In some cases it is not possible to forward a serial device to the container that zigbee2mqtt runs in. This could be because the device is not physically connected to the machine at all. 
+
+Socat can be used to forward a serial device over TCP to zigbee2mqtt. See the [socat man pages](https://linux.die.net/man/1/socat) for more info.
+
+You can configure the socat module within the socat section using the following options:
+
+- `enabled` true/false to enable socat (default: false)
+- `master` master or first address used in socat command line (mandatory)
+- `slave` slave or second address used in socat command line (mandatory)
+- `options` extra options added to the socat command line (optional)
+- `log` true/false if to log the socat stdout/stderr to data_path/socat.log (default: false)
+- `initialdelay` delay (in seconds) to wait when the plugin is started before zigbee2mqtt is started (optional)
+- `restartdelay` delay (in seconds) to wait before a socat process is restarted when it has terminated (optional)
+
+----
 ### Issues
 
 If you find any issues with the addon, please check the [issue tracker](https://github.com/danielwelch/hassio-zigbee2mqtt/issues) for similar issues before creating one. If your issue is regarding specific devices or, more generally, an issue that arises after zigbee2mqtt has successfully started, it should likely be reported in the [zigbee2mqtt issue tracker](https://github.com/Koenkk/zigbee2mqtt/issues)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ You can configure the socat module within the socat section using the following 
 - `initialdelay` delay (in seconds) to wait when the plugin is started before zigbee2mqtt is started (optional)
 - `restartdelay` delay (in seconds) to wait before a socat process is restarted when it has terminated (optional)
 
+**NOTE:** You'll have to change both the `master` and the `slave` options according to your needs. The defaults values will make sure that socat listens on port `8485` and redirects its output to `/dev/ttyZ2M`. The zigbee2mqtt's serial.port setting is NOT automatically set and has to be changed accordingly.
+
 ----
 ### Issues
 

--- a/zigbee2mqtt-edge/Dockerfile
+++ b/zigbee2mqtt-edge/Dockerfile
@@ -8,7 +8,7 @@ ENV COMMIT=$COMMIT
 ENV LANG C.UTF-8
 
 RUN apk add --update --no-cache \
-    jq nodejs nodejs-npm \
+    jq nodejs nodejs-npm socat \
     make gcc g++ linux-headers udev git python2 && \
   git clone -b dev --single-branch --depth 1 https://github.com/Koenkk/zigbee2mqtt.git /app && \
   cd /app && \

--- a/zigbee2mqtt-edge/Dockerfile
+++ b/zigbee2mqtt-edge/Dockerfile
@@ -19,9 +19,11 @@ RUN apk add --update --no-cache \
   rm -rf /app/docs /app/test /app/images /app/scripts /app/data /app/docker /app/LICENSE /app/README.md /app/update.sh
 
 COPY run.sh /app/run.sh
+COPY socat.sh /app/socat.sh
 WORKDIR /app
 
 RUN jq -n '{"hash": env.COMMIT}' > ./.hash.json
 
+RUN ["chmod", "a+x", "./socat.sh"]
 RUN ["chmod", "a+x", "./run.sh"]
 CMD [ "./run.sh" ]

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -21,7 +21,7 @@
     "8485/tcp": 8485
   },
   "ports_description": {
-    "8485/tcp": "Socat port"
+    "8485/tcp": "Socat tcp-listen port"
   },
   "options": {
     "data_path": "/share/zigbee2mqtt",
@@ -47,15 +47,15 @@
     "ban": [],
     "whitelist": [],
     "queue": {},
-	"socat": {
-	  "enabled": false,
+    "socat": {
+      "enabled": false,
       "master": "pty,raw,echo=0,link=/dev/ttyZ2M,mode=777",
       "slave": "tcp-listen:8485,keepalive,nodelay,reuseaddr,keepidle=1,keepintvl=1,keepcnt=5",
-	  "restartdelay": 1,
+      "restartdelay": 1,
       "initialdelay": 1,
       "options": "-d -d",
-	  "log": false
-	}
+      "log": false
+    }
   },
   "schema": {
     "zigbee_shepherd_devices": "bool?",
@@ -113,15 +113,15 @@
       "delay": "int?",
       "simultaneously": "int?"
     },
-	"socat": {
-	  "enabled": "bool?",
+    "socat": {
+      "enabled": "bool?",
       "master": "str?",
       "slave": "str?",
-	  "restartdelay": "float(0,)?",
+      "restartdelay": "float(0,)?",
       "initialdelay": "float(0,)?",
       "options": "str?",
-	  "log": "bool?"
-	}
+      "log": "bool?"
+    }
   },
   "image": "dwelch2101/zigbee2mqtt-edge-{arch}"
 }

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -122,5 +122,6 @@
       "options": "str?",
 	  "log": "bool?"
 	}
-  }
+  },
+  "image": "dwelch2101/zigbee2mqtt-edge-{arch}"
 }

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -116,7 +116,7 @@
 	"socat": {
 	  "enabled": "bool?",
       "master": "str?",
-      "slave": "str?"
+      "slave": "str?",
 	  "restartdelay": "float(0,)?",
       "initialdelay": "float(0,)?",
       "options": "str?",

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -122,6 +122,5 @@
       "options": "str?",
 	  "log": "bool?"
 	}
-  },
-  "image": "dwelch2101/zigbee2mqtt-edge-{arch}"
+  }
 }

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -50,7 +50,7 @@
 	"socat": {
 	  "enabled": false,
       "master": "pty,raw,echo=0,link=/dev/ttyZ2M,mode=777",
-      "slave": "tcp-listen:8485,keepalive,nodelay,reuseaddr,keepidle=1,keepintvl=1,keepcnt=5"
+      "slave": "tcp-listen:8485,keepalive,nodelay,reuseaddr,keepidle=1,keepintvl=1,keepcnt=5",
 	  "restartdelay": 1,
       "initialdelay": 1,
       "options": "-d -d",

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -17,6 +17,12 @@
     "share:rw",
     "config:rw"
   ],
+  "ports": {
+    "8485/tcp": 8485
+  },
+  "ports_description": {
+    "8485/tcp": "Socat port"
+  },
   "options": {
     "data_path": "/share/zigbee2mqtt",
     "devices": "devices.yaml",
@@ -40,7 +46,16 @@
     },
     "ban": [],
     "whitelist": [],
-    "queue": {}
+    "queue": {},
+	"socat": {
+	  "enabled": false,
+      "master": "pty,raw,echo=0,link=/dev/ttyZ2M,mode=777",
+      "slave": "tcp-listen:8485,keepalive,nodelay,reuseaddr,keepidle=1,keepintvl=1,keepcnt=5"
+	  "restartdelay": 1,
+      "initialdelay": 1,
+      "options": "-d -d",
+	  "log": false
+	}
   },
   "schema": {
     "zigbee_shepherd_devices": "bool?",
@@ -97,7 +112,16 @@
     "queue": {
       "delay": "int?",
       "simultaneously": "int?"
-    }
+    },
+	"socat": {
+	  "enabled": "bool?",
+      "master": "str?",
+      "slave": "str?"
+	  "restartdelay": "float(0,)?",
+      "initialdelay": "float(0,)?",
+      "options": "str?",
+	  "log": "bool?"
+	}
   },
   "image": "dwelch2101/zigbee2mqtt-edge-{arch}"
 }

--- a/zigbee2mqtt-edge/run.sh
+++ b/zigbee2mqtt-edge/run.sh
@@ -19,7 +19,7 @@ fi
 mkdir -p "$DATA_PATH"
 
 # Parse config
-cat "$CONFIG_PATH" | jq 'del(.data_path)' | jq 'del(.zigbee_shepherd_debug)' | jq 'del(.zigbee_shepherd_devices)' > $DATA_PATH/configuration.yaml
+cat "$CONFIG_PATH" | jq 'del(.data_path)' | jq 'del(.zigbee_shepherd_debug)' | jq 'del(.zigbee_shepherd_devices)' | jq 'del(.socat)' > $DATA_PATH/configuration.yaml
 
 if [[ ! -z "$ZIGBEE_HERDSMAN_DEBUG" ]]; then
     echo "[Info] Zigbee Herdsman debug logging enabled."
@@ -35,4 +35,9 @@ if [[ ! -z "$ZIGBEE_SHEPHERD_DEVICES" ]]; then
     fi
 fi
 
+# FORK SOCAT IN A SEPARATE PROCESS IF ENABLED
+SOCAT_EXEC="$(dirname $0)/socat.sh"
+$SOCAT_EXEC $CONFIG_PATH
+
+# RUN zigbee2mqtt
 ZIGBEE2MQTT_DATA="$DATA_PATH" pm2-runtime start npm -- start

--- a/zigbee2mqtt-edge/socat.sh
+++ b/zigbee2mqtt-edge/socat.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Configuration and variables
+CONFIG_PATH=$1
+EXEC_TYPE=$2
+DATA_PATH=$(jq --raw-output ".data_path" $CONFIG_PATH)
+SOCAT_ENABLED=$(jq --raw-output ".socat.enabled // empty" $CONFIG_PATH)
+SOCAT_MASTER=$(jq --raw-output ".socat.master // empty" $CONFIG_PATH)
+SOCAT_SLAVE=$(jq --raw-output ".socat.slave // empty" $CONFIG_PATH)
+SOCAT_OPTIONS=$(jq --raw-output ".socat.options // empty" $CONFIG_PATH)
+SOCAT_INITDELAY=$(jq --raw-output ".socat.initialdelay // 1" $CONFIG_PATH)
+SOCAT_RESTDELAY=$(jq --raw-output ".socat.restartdelay // 1" $CONFIG_PATH)
+SOCAT_LOG=$(jq --raw-output ".socat.log // empty" $CONFIG_PATH)
+SCRIPT_PATH=$(realpath "$0")
+
+# Validate input
+if [[ -z "$SOCAT_MASTER" ]]; then
+  echo "[Info] Socat is enabled but not started because no master address specified"
+  exit 0
+fi
+if [[ -z "$SOCAT_SLAVE" ]]; then
+  echo "[Info] Socat is enabled but not started because no slave address specified"
+  exit 0
+fi
+if (("$SOCAT_RESTDELAY" <= "0")); then
+  SOCAT_RESTDELAY=0
+fi
+if (("$SOCAT_INITDELAY" <= "0")); then
+  SOCAT_INITDELAY=0
+fi
+if [[ ! -z "$SOCAT_ENABLED" ]] && [[ "$SOCAT_ENABLED" = true ]]; then
+  SOCAT_LOGFILE="$DATA_PATH/socat.log"
+else
+  SOCAT_LOGFILE=""
+fi
+
+# Forked process, start the socat process within a loop.
+if [[ $EXEC_TYPE = "fork" ]]; then
+  while true; do
+    # Start socat process. This will terminate when when pipe is terminated
+    echo "[Info] Starting socat process"  
+	if [[ -z "$SOCAT_LOGFILE" ]]; then
+      socat $SOCAT_OPTIONS $SOCAT_MASTER $SOCAT_SLAVE 
+    else
+	  socat $SOCAT_OPTIONS $SOCAT_MASTER $SOCAT_SLAVE > $SOCAT_LOGFILE 2>&1
+	fi
+	
+    # Do a sleep after the socat has terminated unexpectedly.
+    echo "[Info] Socat process terminated, restarting after $SOCAT_RESTDELAY sec"  
+    sleep $SOCAT_RESTDELAY
+  done
+  exit 0
+fi
+
+
+# Stop/skip when not enabled or when mandatory variables are empty
+if [[ -z "$SOCAT_ENABLED" ]] || [[ "$SOCAT_ENABLED" = false ]]; then
+  echo "[Info] Socat is DISABLED and not started"
+  exit 0
+fi
+echo "[Info] Socat is ENABLED"
+
+# If there is a log file, print the last 25 lines
+if [[ -f "$SOCAT_LOGFILE" ]]; then
+  echo "[Info] Last 50 lines of the previous socat log file:"
+  tail -n 50 $SOCAT_LOGFILE 
+  echo "[Info] End of socat log file"
+fi
+
+# Start socat by forking this script
+echo "[Info] Starting socat with:"
+echo "[Info] Options:     $SOCAT_OPTIONS"
+echo "[Info] Master:      $SOCAT_MASTER"
+echo "[Info] Slave:       $SOCAT_SLAVE"
+echo "[Info] Logfile:     $SOCAT_LOGFILE"
+echo "[Info] Retrydelay:  $SOCAT_RESTDELAY seconds"
+$SCRIPT_PATH $CONFIG_PATH fork &
+
+# Do an initial sleep
+sleep $SOCAT_INITDELAY

--- a/zigbee2mqtt-edge/socat.sh
+++ b/zigbee2mqtt-edge/socat.sh
@@ -27,7 +27,7 @@ fi
 if (("$SOCAT_INITDELAY" <= "0")); then
   SOCAT_INITDELAY=0
 fi
-if [[ ! -z "$SOCAT_ENABLED" ]] && [[ "$SOCAT_ENABLED" = true ]]; then
+if [[ ! -z "$SOCAT_LOG" ]] && [[ "$SOCAT_LOG" = true ]]; then
   SOCAT_LOGFILE="$DATA_PATH/socat.log"
 else
   SOCAT_LOGFILE=""

--- a/zigbee2mqtt/Dockerfile
+++ b/zigbee2mqtt/Dockerfile
@@ -7,7 +7,7 @@ ENV LANG C.UTF-8
 ENV ZIGBEE2MQTT_VERSION=1.6.0
 ENV ARCHIVE=zigbee2mqtt-$ZIGBEE2MQTT_VERSION
 
-RUN apk add --update --no-cache curl jq nodejs npm \
+RUN apk add --update --no-cache curl jq nodejs npm socat \
     python2 make gcc g++ linux-headers udev git python2 && \
   curl -sL -o "/$ARCHIVE.tar.gz" \
   "https://github.com/Koenkk/zigbee2mqtt/archive/$ZIGBEE2MQTT_VERSION.tar.gz" && \
@@ -19,7 +19,9 @@ RUN apk add --update --no-cache curl jq nodejs npm \
   rm -rf docs test images scripts data docker LICENSE README.md update.sh
 
 COPY run.sh "/$ARCHIVE/run.sh"
+COPY socat.sh "/$ARCHIVE/socat.sh"
 WORKDIR "/$ARCHIVE"
 
+RUN ["chmod", "a+x", "./socat.sh"]
 RUN ["chmod", "a+x", "./run.sh"]
 CMD [ "./run.sh" ]

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -133,7 +133,7 @@
 	"socat": {
 	  "enabled": "bool?",
       "master": "str?",
-      "slave": "str?"
+      "slave": "str?",
 	  "restartdelay": "float(0,)?",
       "initialdelay": "float(0,)?",
       "options": "str?",

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -139,6 +139,5 @@
       "options": "str?",
 	  "log": "bool?"
 	}
-  },
-  "image": "dwelch2101/zigbee2mqtt-{arch}"
+  }
 }

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -17,6 +17,12 @@
     "share:rw",
     "config:rw"
   ],
+  "ports": {
+    "8485/tcp": 8485
+  },
+  "ports_description": {
+    "8485/tcp": "Socat port"
+  },
   "options": {
     "data_path": "/share/zigbee2mqtt",
     "devices": "devices.yaml",
@@ -57,7 +63,16 @@
     },
     "ban": [],
     "whitelist": [],
-    "queue": {}
+    "queue": {},
+	"socat": {
+	  "enabled": false,
+      "master": "pty,raw,echo=0,link=/dev/ttyZ2M,mode=777",
+      "slave": "tcp-listen:8485,keepalive,nodelay,reuseaddr,keepidle=1,keepintvl=1,keepcnt=5"
+	  "restartdelay": 1,
+      "initialdelay": 1,
+      "options": "-d -d",
+	  "log": false
+	}
   },
   "schema": {
     "zigbee_shepherd_devices": "bool?",
@@ -114,7 +129,16 @@
     "queue": {
       "delay": "int?",
       "simultaneously": "int?"
-    }
+    },
+	"socat": {
+	  "enabled": "bool?",
+      "master": "str?",
+      "slave": "str?"
+	  "restartdelay": "float(0,)?",
+      "initialdelay": "float(0,)?",
+      "options": "str?",
+	  "log": "bool?"
+	}
   },
   "image": "dwelch2101/zigbee2mqtt-{arch}"
 }

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -139,5 +139,6 @@
       "options": "str?",
 	  "log": "bool?"
 	}
-  }
+  },
+  "image": "dwelch2101/zigbee2mqtt-{arch}"
 }

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -21,7 +21,7 @@
     "8485/tcp": 8485
   },
   "ports_description": {
-    "8485/tcp": "Socat port"
+    "8485/tcp": "Socat tcp-listen port"
   },
   "options": {
     "data_path": "/share/zigbee2mqtt",
@@ -64,15 +64,15 @@
     "ban": [],
     "whitelist": [],
     "queue": {},
-	"socat": {
-	  "enabled": false,
+    "socat": {
+      "enabled": false,
       "master": "pty,raw,echo=0,link=/dev/ttyZ2M,mode=777",
       "slave": "tcp-listen:8485,keepalive,nodelay,reuseaddr,keepidle=1,keepintvl=1,keepcnt=5",
-	  "restartdelay": 1,
+      "restartdelay": 1,
       "initialdelay": 1,
       "options": "-d -d",
-	  "log": false
-	}
+      "log": false
+    }
   },
   "schema": {
     "zigbee_shepherd_devices": "bool?",
@@ -130,15 +130,15 @@
       "delay": "int?",
       "simultaneously": "int?"
     },
-	"socat": {
-	  "enabled": "bool?",
+    "socat": {
+      "enabled": "bool?",
       "master": "str?",
       "slave": "str?",
-	  "restartdelay": "float(0,)?",
+      "restartdelay": "float(0,)?",
       "initialdelay": "float(0,)?",
       "options": "str?",
-	  "log": "bool?"
-	}
+      "log": "bool?"
+    }
   },
   "image": "dwelch2101/zigbee2mqtt-{arch}"
 }

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -67,7 +67,7 @@
 	"socat": {
 	  "enabled": false,
       "master": "pty,raw,echo=0,link=/dev/ttyZ2M,mode=777",
-      "slave": "tcp-listen:8485,keepalive,nodelay,reuseaddr,keepidle=1,keepintvl=1,keepcnt=5"
+      "slave": "tcp-listen:8485,keepalive,nodelay,reuseaddr,keepidle=1,keepintvl=1,keepcnt=5",
 	  "restartdelay": 1,
       "initialdelay": 1,
       "options": "-d -d",

--- a/zigbee2mqtt/run.sh
+++ b/zigbee2mqtt/run.sh
@@ -18,7 +18,7 @@ if [[ -f $DATA_PATH/configuration.yaml ]]; then
 fi
 
 # Parse config
-cat "$CONFIG_PATH" | jq 'del(.data_path)' | jq 'del(.zigbee_shepherd_debug)' | jq 'del(.zigbee_shepherd_devices)' > $DATA_PATH/configuration.yaml
+cat "$CONFIG_PATH" | jq 'del(.data_path)' | jq 'del(.zigbee_shepherd_debug)' | jq 'del(.zigbee_shepherd_devices)' | jq 'del(.socat)' > $DATA_PATH/configuration.yaml
 
 if [[ ! -z "$ZIGBEE_SHEPHERD_DEBUG" ]]; then
     echo "[Info] Zigbee Shepherd debug logging enabled."
@@ -34,4 +34,9 @@ if [[ ! -z "$ZIGBEE_SHEPHERD_DEVICES" ]]; then
     fi
 fi
 
+# FORK SOCAT IN A SEPARATE PROCESS IF ENABLED
+SOCAT_EXEC="$(dirname $0)/socat.sh"
+$SOCAT_EXEC $CONFIG_PATH
+
+# RUN zigbee2mqtt
 ZIGBEE2MQTT_DATA="$DATA_PATH" pm2-runtime start npm -- start

--- a/zigbee2mqtt/socat.sh
+++ b/zigbee2mqtt/socat.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Configuration and variables
+CONFIG_PATH=$1
+EXEC_TYPE=$2
+DATA_PATH=$(jq --raw-output ".data_path" $CONFIG_PATH)
+SOCAT_ENABLED=$(jq --raw-output ".socat.enabled // empty" $CONFIG_PATH)
+SOCAT_MASTER=$(jq --raw-output ".socat.master // empty" $CONFIG_PATH)
+SOCAT_SLAVE=$(jq --raw-output ".socat.slave // empty" $CONFIG_PATH)
+SOCAT_OPTIONS=$(jq --raw-output ".socat.options // empty" $CONFIG_PATH)
+SOCAT_INITDELAY=$(jq --raw-output ".socat.initialdelay // 1" $CONFIG_PATH)
+SOCAT_RESTDELAY=$(jq --raw-output ".socat.restartdelay // 1" $CONFIG_PATH)
+SOCAT_LOG=$(jq --raw-output ".socat.log // empty" $CONFIG_PATH)
+SCRIPT_PATH=$(realpath "$0")
+
+# Validate input
+if [[ -z "$SOCAT_MASTER" ]]; then
+  echo "[Info] Socat is enabled but not started because no master address specified"
+  exit 0
+fi
+if [[ -z "$SOCAT_SLAVE" ]]; then
+  echo "[Info] Socat is enabled but not started because no slave address specified"
+  exit 0
+fi
+if (("$SOCAT_RESTDELAY" <= "0")); then
+  SOCAT_RESTDELAY=0
+fi
+if (("$SOCAT_INITDELAY" <= "0")); then
+  SOCAT_INITDELAY=0
+fi
+if [[ ! -z "$SOCAT_ENABLED" ]] && [[ "$SOCAT_ENABLED" = true ]]; then
+  SOCAT_LOGFILE="$DATA_PATH/socat.log"
+else
+  SOCAT_LOGFILE=""
+fi
+
+# Forked process, start the socat process within a loop.
+if [[ $EXEC_TYPE = "fork" ]]; then
+  while true; do
+    # Start socat process. This will terminate when when pipe is terminated
+    echo "[Info] Starting socat process"  
+	if [[ -z "$SOCAT_LOGFILE" ]]; then
+      socat $SOCAT_OPTIONS $SOCAT_MASTER $SOCAT_SLAVE 
+    else
+	  socat $SOCAT_OPTIONS $SOCAT_MASTER $SOCAT_SLAVE > $SOCAT_LOGFILE 2>&1
+	fi
+	
+    # Do a sleep after the socat has terminated unexpectedly.
+    echo "[Info] Socat process terminated, restarting after $SOCAT_RESTDELAY sec"  
+    sleep $SOCAT_RESTDELAY
+  done
+  exit 0
+fi
+
+
+# Stop/skip when not enabled or when mandatory variables are empty
+if [[ -z "$SOCAT_ENABLED" ]] || [[ "$SOCAT_ENABLED" = false ]]; then
+  echo "[Info] Socat is DISABLED and not started"
+  exit 0
+fi
+echo "[Info] Socat is ENABLED"
+
+# If there is a log file, print the last 25 lines
+if [[ -f "$SOCAT_LOGFILE" ]]; then
+  echo "[Info] Last 50 lines of the previous socat log file:"
+  tail -n 50 $SOCAT_LOGFILE 
+  echo "[Info] End of socat log file"
+fi
+
+# Start socat by forking this script
+echo "[Info] Starting socat with:"
+echo "[Info] Options:     $SOCAT_OPTIONS"
+echo "[Info] Master:      $SOCAT_MASTER"
+echo "[Info] Slave:       $SOCAT_SLAVE"
+echo "[Info] Logfile:     $SOCAT_LOGFILE"
+echo "[Info] Retrydelay:  $SOCAT_RESTDELAY seconds"
+$SCRIPT_PATH $CONFIG_PATH fork &
+
+# Do an initial sleep
+sleep $SOCAT_INITDELAY

--- a/zigbee2mqtt/socat.sh
+++ b/zigbee2mqtt/socat.sh
@@ -27,7 +27,7 @@ fi
 if (("$SOCAT_INITDELAY" <= "0")); then
   SOCAT_INITDELAY=0
 fi
-if [[ ! -z "$SOCAT_ENABLED" ]] && [[ "$SOCAT_ENABLED" = true ]]; then
+if [[ ! -z "$SOCAT_LOG" ]] && [[ "$SOCAT_LOG" = true ]]; then
   SOCAT_LOGFILE="$DATA_PATH/socat.log"
 else
   SOCAT_LOGFILE=""


### PR DESCRIPTION
Adds the very small socat package (https://pkgs.alpinelinux.org/package/edge/main/x86/socat) and a script to fork a socat process within the zigbee2mqtt container. The goal is enable zigbee2mqtt to access a serial device over the network via TCP.

This can be very usefull in the scenario where the zigbee stick isn't physically connected to the hass.io machine. Also when you do not have access to the operating system itself (like with the hassos appliances or VMs) it can be very difficult to add a virtual serial device within the zigbee2mqtt docker container.

Socat is a relay tool for bidirectional data transfer between two data channels. By default the socat parameters are configured to listen on port 8485 and redirect it to a virtual device named /dev/ttyZ2M. This device can then be used in zigbee2mqtt for to access the serial device.

Socat is configured via a separate 'socat' section within the options. The section is completely optional to make it backwards compatible with older configurations. The socat functionality is disabled by default on new installations.