### PR TITLE
Add config parameters to enable livolo integration

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -89,6 +89,9 @@
     ],
     "advanced": {
       "pan_id": "int(0,65536)?",
+      "ext_pan_id": [
+        "match(0x[0-9a-fA-F]+|[0-9]+)?"
+      ],      
       "channel": "int(11,26)?",
       "cache_state": "bool?",
       "log_level": "match(^info|debug|warn|error$)?",
@@ -107,7 +110,10 @@
       ],
       "report": "bool?",
       "homeassistant_discovery_topic": "str?",
-      "homeassistant_status_topic": "str?"
+      "homeassistant_status_topic": "str?",
+      "experimental": {
+        "livolo": "bool?"
+      }
     },
     "queue": {
       "delay": "int?",

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -40,6 +40,10 @@
     },
     "advanced": {
       "pan_id": 6754,
+      "ext_pan_id": ["0xDD", "0xDD", "0xDD", "0xDD", "0xDD", "0xDD", "0xDD", "0xDD"],
+      "experimental": {
+        "livolo": "false"  
+      },
       "channel": 11,
       "network_key": [1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13],
       "availability_blacklist": []


### PR DESCRIPTION
Add the possibility of setting ext_pan_id and experimental (livolo) to allow users of the edge (dev) version of zigbee2mqtt to use livolo switches.  https://github.com/Koenkk/zigbee2mqtt/issues/592