### PR TITLE
Upgrade to v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@
 <p>Run Zigbee2mqtt as a Hass.io Add-on</p>
 </div>
 
-## Warning: Breaking Changes in version 1.5.1
+## Warning: Breaking Changes in version 1.7.0 
+Once upgraded from 1.6.0 to 1.7.0 you cannot switch back to 1.6.0 when not having a backup of the database.db! 
 
+## Warning: Breaking Changes in version 1.5.1 
 Version 1.5.1 contains breaking changes and requires re-formating of the add-on configuration. Please see the updated configuration documentation below.
 
 #### Restoring Configuration after upgrading to 1.5.1

--- a/zigbee2mqtt/Dockerfile
+++ b/zigbee2mqtt/Dockerfile
@@ -4,7 +4,7 @@ FROM $BUILD_FROM
 # Add env
 ENV LANG C.UTF-8
 
-ENV ZIGBEE2MQTT_VERSION=1.6.0
+ENV ZIGBEE2MQTT_VERSION=1.7.0
 ENV ARCHIVE=zigbee2mqtt-$ZIGBEE2MQTT_VERSION
 
 RUN apk add --update --no-cache curl jq nodejs npm socat \

--- a/zigbee2mqtt/README.md
+++ b/zigbee2mqtt/README.md
@@ -14,4 +14,6 @@
 </div>
 
 # WARNING! Breaking Changes Notice
-Version 1.5.1 contains breaking changes! See the documentation on https://github.com/danielwelch/hassio-zigbee2mqtt for more information. The breaking change is from 1.4 to 1.5.1+, therefore, if you have version 1.4 and you are upgrade the version, check the documentation.
+Once upgraded from 1.6.0 to 1.7.0 you cannot switch back to 1.6.0 when not having a backup of the database.db!
+
+If you upgrade from older versions: Version 1.5.1 contains breaking changes! See the documentation on https://github.com/danielwelch/hassio-zigbee2mqtt for more information. The breaking change is from 1.4 to 1.5.1+, therefore, if you have version 1.4 and you are upgrade the version, check the documentation.

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "zigbee2mqtt",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "slug": "zigbee2mqtt",
   "description": "Zigbee to MQTT Bridge",
   "auto_uart": true,


### PR DESCRIPTION
(Hopefully) the needed pull request to implement #253. My understanding of the lack of specific upgrade instructions on the `zigbee2mqtt` `1.7.0` release is, that the upgrade should be painless (i.e. automatic). Correct me if I'm wrong.

I also expanded on the "breaking changes" in the `README.md`, adding the specific note for `1.6.0` to `1.7.0` release notes from the [1.7.0 release notes](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.7.0).