### PR TITLE
Support extended PAN ID (optional) & secret network_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 This project is versioned based upon the version of [zigbee2mqtt](https://github.com/Koenkk/zigbee2mqtt). The versioning `X.Y.Z` of the stable release of this add-on will track that of zigbee2mqtt. If there are new releases without upgrades to the zigbee2mqtt version (i.e., changes to the add-on that occur between releases of zigbee2mqtt), an additional number will be added to indicate this (`X.Y.Z.A`, where `A` indicates a new versioned release).
 
+## 1.10.1 - 2020-02-?
+### Added
+- Added config options `network_key_string` and `ext_pan_id_string`.
+
 ## 1.10.0 - 2019-02-06
 ### Changed
 - Upgrade zigbe22mqtt to 1.10.0

--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ The repository includes two add-ons: **zigbee2mqtt** and **zigbee2mqtt-edge**. F
 
 Configure the add-on via the Hass.io front-end. The configuration closely mirrors that of `zigbee2mqtt` itself, with a couple of key differences:
 1. Hass.io requires add-on configuration in JSON format, rather than YAML. If you don't understand the difference, you can use a YAML-to-JSON converter.
-2. An additional top-level `data-path` option is required. Set this to the path where like the add-on to persist data. Defaults to `/share/zigbee2mqtt`. Note that both `config` and `share` directories are mapped into the container (read-write) and are available to you.
+2. An additional top-level `data-path` option is required. Set this to the path where you would like the add-on to persist data. Defaults to `/share/zigbee2mqtt`. Note that both `config` and `share` directories are mapped into the container (read-write) and are available to you.
 3. If you are using groups or device-specific settings, you must use seperate files, and provide the paths to these files in their corresponding config options as described by the zigbee2mqtt docs. This is due to a limitation Hass.io places on nested config levels.
 
 See the [zigbee2mqtt configuration docs](https://www.zigbee2mqtt.io/information/configuration.html) for a complete description of available options. If you're not sure if a new option is supported, check to see if it is included in this repository's `zigbee2mqtt/config.json` or `zigbee2mqtt_edge/config.json` `schema`. If not, you can open an issue to add support for it.
 
-- Depending on your configuration, the MQTT server config will need to include the port, typically `1883` or `8883` for SSL communications. For example, `mqtt://core-mosquitto:1883` for Hass.io's Mosquitto addon.
-- To find out which serial ports you have exposed go to **Hass.io > System > Host system > Show Hardware**
+- Depending on your configuration, the MQTT server config may need to include the port, typically `1883` or `8883` for SSL communications. For example, `mqtt://core-mosquitto:1883` for Hass.io's Mosquitto addon.
+- To find out which serial ports you have exposed go to **Supervisor (used to be Hass.io) > System > Host system > Hardware**
 
 ## Pairing
 

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -89,6 +89,7 @@
     ],
     "advanced": {
       "pan_id": "int(0,65536)?",
+      "ext_pan_id_string": "match(^(\\s*\\d+\\s*,){7}(\\s*\\d+\\s*)$)?",
       "channel": "int(11,26)?",
       "cache_state": "bool?",
       "log_level": "match(^info|debug|warn|error$)?",
@@ -99,6 +100,7 @@
       "network_key": [
         "int?"
       ],
+      "network_key_string": "match(^(\\s*\\d+\\s*,){15}(\\s*\\d+\\s*)$)?",
       "last_seen": "match(^disable|ISO_8601|epoch)?",
       "elapsed": "bool?",
       "availability_timeout": "int?",

--- a/zigbee2mqtt-edge/run.sh
+++ b/zigbee2mqtt-edge/run.sh
@@ -28,7 +28,10 @@ fi
 mkdir -p "$DATA_PATH"
 
 # Parse config
-cat "$CONFIG_PATH" | jq 'del(.data_path)' | jq 'del(.zigbee_shepherd_debug)' | jq 'del(.zigbee_shepherd_devices)' | jq 'del(.socat)' > $DATA_PATH/configuration.yaml
+cat "$CONFIG_PATH" | jq 'del(.data_path, .zigbee_shepherd_debug, .zigbee_shepherd_devices, .socat)' \
+    | jq 'if .advanced.ext_pan_id_string then .advanced.ext_pan_id = (.advanced.ext_pan_id_string | (split(",")|map(tonumber))) | del(.advanced.ext_pan_id_string) else . end' \
+    | jq 'if .advanced.network_key_string then .advanced.network_key = (.advanced.network_key_string | (split(",")|map(tonumber))) | del(.advanced.network_key_string) else . end' \
+    > $DATA_PATH/configuration.yaml
 
 if [[ ! -z "$ZIGBEE_HERDSMAN_DEBUG" ]]; then
     echo "[Info] Zigbee Herdsman debug logging enabled."

--- a/zigbee2mqtt/README.md
+++ b/zigbee2mqtt/README.md
@@ -17,3 +17,30 @@
 Once upgraded from 1.6.0 to 1.7.0 you cannot switch back to 1.6.0 when not having a backup of the database.db!
 
 If you upgrade from older versions: Version 1.5.1 contains breaking changes! See the documentation on https://github.com/danielwelch/hassio-zigbee2mqtt for more information. The breaking change is from 1.4 to 1.5.1+, therefore, if you have version 1.4 and you are upgrade the version, check the documentation.
+
+# Configuration
+The configuration closely mirrors that of `zigbee2mqtt` itself, with a couple of key differences:
+1. Hass.io requires add-on configuration in JSON format, rather than YAML. If you don't understand the difference, you can use a YAML-to-JSON converter.
+2. An additional top-level `data-path` option is required. Set this to the path where you would like the add-on to persist data. Defaults to `/share/zigbee2mqtt`. Note that both `config` and `share` directories are mapped into the container (read-write) and are available to you.
+3. If you are using groups or device-specific settings, you must use seperate files, and provide the paths to these files in their corresponding config options as described by the zigbee2mqtt docs. This is due to a limitation Hass.io places on nested config levels.
+
+See the [zigbee2mqtt configuration docs](https://www.zigbee2mqtt.io/information/configuration.html) for a complete description of available options. If you're not sure if a new option is supported, check to see if it is included in this add-on's default configuration. If not, you can open an issue to add support for it.
+
+# Notes
+- Depending on your configuration, the MQTT server config may need to include the port, typically `1883` or `8883` for SSL communications. For example, `mqtt://core-mosquitto:1883` for Hass.io's Mosquitto addon.
+- To find out which serial ports you have exposed go to **Supervisor (used to be Hass.io) > System > Host system > Hardware**
+- Please see this add-on's [documentation on GitHub](https://github.com/danielwelch/hassio-zigbee2mqtt#socat) for further add-on-specific information (using Socat, how to add support for new devices etc.).
+
+# Additional Configuration Options
+- `network_key_string`  
+This setting can be used instead of the normal array in case you would like the network key to be read from the secrets file (strings can be read from the secrets file whereas arrays cannot). Please note that `network_key` still needs to be present in the configuration (arrays being mandatory), but it may just be an empty array (it will be overwritten by the contents of `network_key_string` anyway).
+- `ext_pan_id_string`  
+Extended PAN ID has only been implemented as a string setting instead of an array to allow it to be optional and to not break existing configurations (strings can be optional whereas arrays cannot).
+
+Examples:
+```yaml
+advanced:
+  network_key: []
+  network_key_string: '!secret zigbee2mqt_network_key'
+  ext_pan_id_string: '221, 221, 221, 221, 221, 221, 221, 221'
+```

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -107,6 +107,7 @@
     ],
     "advanced": {
       "pan_id": "int(0,65536)?",
+      "ext_pan_id_string": "match(^(\\s*\\d+\\s*,){7}(\\s*\\d+\\s*)$)?",
       "channel": "int(11,26)?",
       "cache_state": "bool?",
       "log_level": "match(^info|debug|warn|error$)?",
@@ -117,6 +118,7 @@
       "network_key": [
         "int?"
       ],
+      "network_key_string": "match(^(\\s*\\d+\\s*,){15}(\\s*\\d+\\s*)$)?",
       "last_seen": "match(^disable|ISO_8601|epoch)?",
       "elapsed": "bool?",
       "availability_timeout": "int?",

--- a/zigbee2mqtt/run.sh
+++ b/zigbee2mqtt/run.sh
@@ -19,7 +19,10 @@ if [[ -f $DATA_PATH/configuration.yaml ]]; then
 fi
 
 # Parse config
-cat "$CONFIG_PATH" | jq 'del(.data_path)' | jq 'del(.zigbee_shepherd_debug)' | jq 'del(.zigbee_shepherd_devices)' | jq 'del(.socat)' > $DATA_PATH/configuration.yaml
+cat "$CONFIG_PATH" | jq 'del(.data_path, .zigbee_shepherd_debug, .zigbee_shepherd_devices, .socat)' \
+    | jq 'if .advanced.ext_pan_id_string then .advanced.ext_pan_id = (.advanced.ext_pan_id_string | (split(",")|map(tonumber))) | del(.advanced.ext_pan_id_string) else . end' \
+    | jq 'if .advanced.network_key_string then .advanced.network_key = (.advanced.network_key_string | (split(",")|map(tonumber))) | del(.advanced.network_key_string) else . end' \
+    > $DATA_PATH/configuration.yaml
 
 if [[ ! -z "$ZIGBEE_SHEPHERD_DEBUG" ]]|| [[ ! -z "$ZIGBEE_HERDSMAN_DEBUG" ]]; then
     echo "[Info] Zigbee Herdsman debug logging enabled."


### PR DESCRIPTION
Support both extended PAN ID and network key *as strings*. That way
* extended PAN ID can be made optional (arrays cannot be made optional in the Hass.io add-on schema, so adding it - being mandatory - would break existing installations)
* the network key can be read from the secrets file (strings can be read from the secrets file whereas arrays can not)

Follow up to https://github.com/danielwelch/hassio-zigbee2mqtt/pull/263 and https://github.com/danielwelch/hassio-zigbee2mqtt/issues/259.

Example configuration:
```javascript
{
  // ...
  "advanced": {
    // ...
    "ext_pan_id_string": "1, 2, 3, 4, 5, 6, 7, 8",
    // ...
    "network_key": [],
    "network_key_string": "1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13",
    // ...
  },
  // ...
}
```
Please note that `network_key` still needs to be present in the configuration (arrays being mandatory), but it may just be an empty array (it will be overwritten by the contents of `network_key_string` anyway).