### PR TITLE
mount ssl folder from hass to use certificate

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -14,6 +14,7 @@
   ],
   "boot": "auto",
   "map": [
+    "ssl",
     "share:rw",
     "config:rw"
   ],


### PR DESCRIPTION
Hello,

Thx for your addon.
I wanted use my own ssl secured connection. But I didn't want copy certificate en several path;
So I change the config.json to mount ssl folder from hass.
It's described in this documentation section "map".
https://developers.home-assistant.io/docs/en/next/hassio_addon_config.html#options--schema

Sincerely,
Turiok