### PR TITLE
Add support of experimental transmit_power feature to zigbee2mqtt stable.

### DIFF
--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -64,6 +64,7 @@
     "ban": [],
     "whitelist": [],
     "queue": {},
+    "experimental": {},
     "socat": {
       "enabled": false,
       "master": "pty,raw,echo=0,link=/dev/ttyZ2M,mode=777",
@@ -132,6 +133,9 @@
     "queue": {
       "delay": "int?",
       "simultaneously": "int?"
+    },
+    "experimental": {
+      "transmit_power": "int(-22,19)?"
     },
     "socat": {
       "enabled": "bool?",


### PR DESCRIPTION
See https://github.com/Koenkk/zigbee2mqtt/issues/2253