### PR TITLE
Add support for availability_whitelist to edge version of addon

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -106,6 +106,9 @@
       "last_seen": "match(^disable|ISO_8601|epoch)?",
       "elapsed": "bool?",
       "availability_timeout": "int?",
+      "availability_whitelist": [
+        "str?"
+      ],
       "availability_blacklist": [
         "str?"
       ],


### PR DESCRIPTION
Add availability_whitelist as an configuration option.

<!-- If this pull request updates the version of the stable version of the add-on, please complete the checklist below. Otherwise, please delete it. -->

#### Checklist

- [x] Change the version number in `zigbee2mqtt/Dockerfile`: `ENV ZIGBEE2MQTT_VERSION="$NEW_VERSION"`
- [x] Change the version number in `zigbee2mqtt/config.json`: `"version": "$NEW_VERSION"`
- [x] Add any new configuration options to `zigbee2mqtt/config.json` and `zigbee2mqtt-edge/config.json`.
- [x] Update the changelog, including any breaking changes, changes to underlying libraries, or new configuration options
