### PR TITLE
Add support of experimental transmit_power feature to zigbee2mqtt.

### DIFF
--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -63,6 +63,7 @@
     },
     "ban": [],
     "whitelist": [],
+    "experimental": {},
     "queue": {},
     "socat": {
       "enabled": false,
@@ -128,6 +129,9 @@
       "report": "bool?",
       "homeassistant_discovery_topic": "str?",
       "homeassistant_status_topic": "str?"
+    },
+    "experimental": {
+      "transmit_power": "int?"
     },
     "queue": {
       "delay": "int?",


### PR DESCRIPTION
Correction for https://github.com/danielwelch/hassio-zigbee2mqtt/pull/304.
Looks like negative integer values are not supported in range matcher. Range matcher has been removed as it was done in edge version.