### PR TITLE
Update config.json

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -57,7 +57,8 @@
       "initialdelay": 1,
       "options": "-d -d",
       "log": false
-    }
+    },
+    "external_converters": []
   },
   "schema": {
     "zigbee_shepherd_devices": "bool?",
@@ -128,7 +129,8 @@
       "initialdelay": "float(0,)?",
       "options": "str?",
       "log": "bool?"
-    }
+    },
+    "external_converters": ["str?"]
   },
   "image": "dwelch2101/zigbee2mqtt-edge-{arch}"
 }

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -72,7 +72,8 @@
       "initialdelay": 1,
       "options": "-d -d",
       "log": false
-    }
+    },
+    "external_converters": []
   },
   "schema": {
     "zigbee_shepherd_devices": "bool?",
@@ -141,7 +142,8 @@
       "initialdelay": "float(0,)?",
       "options": "str?",
       "log": "bool?"
-    }
+    },
+    "external_converters": ["str?"]
   },
   "image": "dwelch2101/zigbee2mqtt-{arch}"
 }


### PR DESCRIPTION
Add external_converters configuration support
More details here https://github.com/Koenkk/zigbee-herdsman-converters/issues/1343

<!-- If this pull request updates the version of the stable version of the add-on, please complete the checklist below. Otherwise, please delete it. -->

#### Checklist

- [ ] Change the version number in `zigbee2mqtt/Dockerfile`: `ENV ZIGBEE2MQTT_VERSION="$NEW_VERSION"`
- [ ] Change the version number in `zigbee2mqtt/config.json`: `"version": "$NEW_VERSION"`
- [x] Add any new configuration options to `zigbee2mqtt/config.json` and `zigbee2mqtt-edge/config.json`.
- [ ] Update the changelog, including any breaking changes, changes to underlying libraries, or new configuration options
