### PR TITLE
Add advanced setting homeassistant_legacy_triggers

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -112,7 +112,8 @@
       ],
       "report": "bool?",
       "homeassistant_discovery_topic": "str?",
-      "homeassistant_status_topic": "str?"
+      "homeassistant_status_topic": "str?",
+      "homeassistant_legacy_triggers": "bool?"
     },
     "queue": {
       "delay": "int?",

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -128,7 +128,8 @@
       ],
       "report": "bool?",
       "homeassistant_discovery_topic": "str?",
-      "homeassistant_status_topic": "str?"
+      "homeassistant_status_topic": "str?",
+      "homeassistant_legacy_triggers": "bool?"
     },
     "queue": {
       "delay": "int?",


### PR DESCRIPTION
Adds support for the advanced setting `homeassistant_legacy_triggers`

Zigbee2mqtt issue: Koenkk/zigbee2mqtt#3033

Fixes #313, #375