### PR TITLE
adding adapter_concurrent option to config

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -100,6 +100,7 @@
       "baudrate": "int?",
       "rtscts": "bool?",
       "soft_reset_timeout": "int?",
+      "adapter_concurrent": "int?",
       "network_key": [
         "int?"
       ],

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -116,6 +116,7 @@
       "baudrate": "int?",
       "rtscts": "bool?",
       "soft_reset_timeout": "int?",
+      "adapter_concurrent": "int?",
       "network_key": [
         "int?"
       ],


### PR DESCRIPTION
Adds the "adapter_concurrent" option. 
https://github.com/Koenkk/zigbee-herdsman/pull/159


https://github.com/Koenkk/zigbee2mqtt/issues/4250