### PR TITLE
add explicit armv7 support; fix .hash.json generation

### DIFF
--- a/zigbee2mqtt-edge/Dockerfile
+++ b/zigbee2mqtt-edge/Dockerfile
@@ -22,7 +22,7 @@ COPY run.sh /app/run.sh
 COPY socat.sh /app/socat.sh
 WORKDIR /app
 
-RUN jq -n '{"hash": env.COMMIT}' > ./.hash.json
+RUN jq -n --arg commit $(eval git rev-parse --short HEAD) '{"hash": $commit }' > ./.hash.json
 
 RUN ["chmod", "a+x", "./socat.sh"]
 RUN ["chmod", "a+x", "./run.sh"]

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -10,6 +10,7 @@
     "aarch64",
     "amd64",
     "armhf",
+    "armv7",
     "i386"
   ],
   "boot": "auto",

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -10,6 +10,7 @@
     "aarch64",
     "amd64",
     "armhf",
+    "armv7",
     "i386"
   ],
   "boot": "auto",


### PR DESCRIPTION
<!-- If this pull request updates the version of the stable version of the add-on, please complete the checklist below. Otherwise, please delete it. -->

#### Checklist

- [ ] Change the version number in `zigbee2mqtt/Dockerfile`: `ENV ZIGBEE2MQTT_VERSION="$NEW_VERSION"`
- [ ] Change the version number in `zigbee2mqtt/config.json`: `"version": "$NEW_VERSION"`
- [ ] Add any new configuration options to `zigbee2mqtt/config.json` and `zigbee2mqtt-edge/config.json`.
- [ ] Update the changelog, including any breaking changes, changes to underlying libraries, or new configuration options