### PR TITLE
Fixes addon startup according to docs

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -5,7 +5,7 @@
   "description": "Development build of the zigbee2mqtt add-on",
   "auto_uart": true,
   "url": "https://github.com/danielwelch/hassio-zigbee2mqtt",
-  "startup": "before",
+  "startup": "application",
   "arch": [
     "aarch64",
     "amd64",

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -5,7 +5,7 @@
   "description": "Zigbee to MQTT Bridge",
   "auto_uart": true,
   "url": "https://github.com/danielwelch/hassio-zigbee2mqtt",
-  "startup": "before",
+  "startup": "application",
   "arch": [
     "aarch64",
     "amd64",


### PR DESCRIPTION
Fixes #364 better.

Fixes value for `startup` according to [documentation](https://developers.home-assistant.io/docs/add-ons/configuration).
This should delay the add-on startup until after Home Assistant is up, and possibly also [Mosquitto](https://github.com/home-assistant/hassio-addons/blob/master/mosquitto/config.json#L8)

Later edit: Used to be `before` and `after` but got documented later. Seems `before` is aliased as `services` and `after` as `application` according to [code](https://github.com/home-assistant/supervisor/blob/dev/supervisor/addons/validate.py#L175) but it's best to use the official documentation suggestion.

#### Checklist

- [x] Change the version number in `zigbee2mqtt/Dockerfile`: `ENV ZIGBEE2MQTT_VERSION="$NEW_VERSION"`
- [x] Change the version number in `zigbee2mqtt/config.json`: `"version": "$NEW_VERSION"`
- [x] Add any new configuration options to `zigbee2mqtt/config.json` and `zigbee2mqtt-edge/config.json`.
- [x] Update the changelog, including any breaking changes, changes to underlying libraries, or new configuration options
