### PR TITLE
add more device options

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -137,6 +137,9 @@
     "device_options": {
       "occupancy_timeout": "int?",
       "temperature_precision": "int?",
+      "humidity_precision": "int?",
+      "pressure_precision": "int?",
+      "debounce": "int?",
       "legacy": "bool?"
     },
     "device_options_string": "str?",

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -137,6 +137,9 @@
     "device_options": {
       "occupancy_timeout": "int?",
       "temperature_precision": "int?",
+      "humidity_precision": "int?",
+      "pressure_precision": "int?",
+      "debounce": "int?",
       "legacy": "bool?"
     },
     "device_options_string": "str?",


### PR DESCRIPTION
Add debounce, humidity and pressure to device options. They're poorly documented in z2m, but do work. I believe these are the major ones.

See the test for them here: https://github.com/Koenkk/zigbee2mqtt/blob/654817a66df951f4b8c93399868ebfb287c9aeb0/test/homeassistant.test.js#L193

And Koen comment here: https://github.com/Koenkk/zigbee2mqtt/issues/3004

The originally documented ones are supported already: https://www.zigbee2mqtt.io/information/configuration.html#changing-device-type-specific-defaults