### PR TITLE
Add support for experimental frontend in edge

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -14,6 +14,10 @@
     "i386"
   ],
   "boot": "auto",
+  "ingress": true,
+  "ingress_port": 8080,
+  "panel_icon": "mdi:zigbee",
+  "panel_title": "Zigbee2Mqtt",
   "map": [
     "ssl",
     "share:rw",
@@ -53,7 +57,10 @@
     "blocklist": [],
     "passlist": [],
     "queue": {},
-    "experimental": {},
+    "experimental": {
+      "new_api": true,
+      "frontend": true
+    },
     "socat": {
       "enabled": false,
       "master": "pty,raw,echo=0,link=/dev/ttyZ2M,mode=777",
@@ -146,7 +153,9 @@
     },
     "experimental": {
       "transmit_power": "int?",
-      "output": "str?"
+      "output": "str?",
+      "new_api": "bool?",
+      "frontend": "bool?"
     },
     "socat": {
       "enabled": "bool?",


### PR DESCRIPTION
Add support for experimental frontend in edge so people can troubleshoot easier. 
Part of testing for https://github.com/danielwelch/hassio-zigbee2mqtt/issues/397

#### Checklist

- [ ] Change the version number in `zigbee2mqtt/Dockerfile`: `ENV ZIGBEE2MQTT_VERSION="$NEW_VERSION"`
- [ ] Change the version number in `zigbee2mqtt/config.json`: `"version": "$NEW_VERSION"`
- [ ] Add any new configuration options to `zigbee2mqtt/config.json` and `zigbee2mqtt-edge/config.json`.
- [ ] Update the changelog, including any breaking changes, changes to underlying libraries, or new configuration options

I will not add the settings in `stable` as probably settings will change. 