### PR TITLE
New configuration option advanced/adapter_delay and adapter: zigate, fixes #499, #498

### DIFF
--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -124,6 +124,7 @@
       "rtscts": "bool?",
       "soft_reset_timeout": "int?",
       "adapter_concurrent": "int?",
+      "adapter_delay": "int?",
       "network_key": [
         "int?"
       ],

--- a/zigbee2mqtt-edge/config.json
+++ b/zigbee2mqtt-edge/config.json
@@ -100,7 +100,7 @@
     "serial": {
       "port": "str",
       "disable_led": "bool?",
-      "adapter": "match(^zstack|deconz$)?"
+      "adapter": "match(^zstack|deconz|zigate$)?"
     },
     "blocklist": [
       "str?"

--- a/zigbee2mqtt/CHANGELOG.md
+++ b/zigbee2mqtt/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.17.0.1
+- New configuration option
+    - `advanced`
+        - `adapter_delay`
+
 ## 1.17.0
 - Updated Zigbee2mqtt to version [`1.17.0`](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.17.0)
 

--- a/zigbee2mqtt/CHANGELOG.md
+++ b/zigbee2mqtt/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## 1.17.0.1
-- New configuration option
+- New configuration options
     - `advanced`
         - `adapter_delay`
+    - `serial`
+        - `adapter: zigate`
 
 ## 1.17.0
 - Updated Zigbee2mqtt to version [`1.17.0`](https://github.com/Koenkk/zigbee2mqtt/releases/tag/1.17.0)

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -1,6 +1,6 @@
 {
   "name": "Zigbee2mqtt",
-  "version": "1.17.0",
+  "version": "1.17.0.1",
   "slug": "zigbee2mqtt",
   "description": "Zigbee to MQTT Bridge",
   "auto_uart": true,
@@ -124,6 +124,7 @@
       "rtscts": "bool?",
       "soft_reset_timeout": "int?",
       "adapter_concurrent": "int?",
+      "adapter_delay": "int?",
       "network_key": [
         "int?"
       ],

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -100,7 +100,7 @@
     "serial": {
       "port": "str",
       "disable_led": "bool?",
-      "adapter": "match(^zstack|deconz$)?"
+      "adapter": "match(^zstack|deconz|zigate$)?"
     },
     "blocklist": [
       "str?"


### PR DESCRIPTION
<!-- If this pull request updates the version of the stable version of the add-on, please complete the checklist below. Otherwise, please delete it. -->

#### Checklist

- [x] Change the version number in `zigbee2mqtt/config.json`: `"version": "$NEW_VERSION"`
- [x] Add any new configuration options to `zigbee2mqtt/config.json` and `zigbee2mqtt-edge/config.json`.
- [x] Update the changelog, including any breaking changes, changes to underlying libraries, or new configuration options
