### PR TITLE
add adapter ezsp

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
   "name": "Home Assistant Add-on: Zigbee2mqtt",
-  "url": "https://www.zigbee2mqtt.io",
+  "url": "https://github.com/zeng5200/hassio-zigbee2mqtt",
   "maintainer": "Daniel Welch <dwelch2102@gmail.com>"
 }

--- a/zigbee2mqtt/config.json
+++ b/zigbee2mqtt/config.json
@@ -95,7 +95,7 @@
     "serial": {
       "port": "str",
       "disable_led": "bool?",
-      "adapter": "match(^zstack|deconz|zigate$)?"
+      "adapter": "match(^zstack|deconz|ezsp|zigate$)?"
     },
     "blocklist": [
       "str?"


### PR DESCRIPTION
comfig adapter ezsp will report error follow:
Failed to save add-on configuration, does not match regular expression ^zstack|deconz|zigate$. Got {'data_path': '/config/zigbee2mqtt', 'external_converters': [], 'devices': 'devices.yaml', 'groups': 'groups.yaml', 'homeassistant': True, 'permit_join': False, 'mqtt': {'base_topic': 'zigbee2mqtt'}, 'serial': {'port': '/dev/ttyUSB0', 'adapter': 'ezsp'}, 'advanced': {'log_level': 'warn', 'pan_id': 6754, 'channel': 11, 'network_key': [1, 3, 5, 7, 9, 11, 13, 15, 0, 2, 4, 6, 8, 10, 12, 13], 'availability_blocklist': [], 'availability_passlist': []}, 'device_options': {}, 'blocklist': [], 'passli...